### PR TITLE
Add python module "simplejson" to manifest file requirements section

### DIFF
--- a/custom_components/badnest/manifest.json
+++ b/custom_components/badnest/manifest.json
@@ -6,6 +6,6 @@
   "codeowners": [
     "@badguy99"
   ],
-  "requirements": [],
+  "requirements": ["simplejson>=3.17.2"],
   "version": "5.0.0"
 }


### PR DESCRIPTION
Fix TravisCI build failure verifying Home Assistant configuration due to missing requirement.